### PR TITLE
[로그인, 회원가입 구현 완료] Feat: 버튼 클릭 시, 페이지 이동 가능하게 처리 (+ CSS)

### DIFF
--- a/src/app/sign/signin/page.tsx
+++ b/src/app/sign/signin/page.tsx
@@ -9,6 +9,7 @@ import { Input } from '@nextui-org/react';
 import { EyeFilledIcon } from '../EyeFilledIcon';
 import { EyeSlashFilledIcon } from '../EyeSlashFilledIcon';
 import { Button } from '@nextui-org/react';
+import Link from 'next/link';
 
 const SignInPage = () => {
   const [email, setEmail] = useState('');
@@ -107,7 +108,7 @@ const SignInPage = () => {
       <form onSubmit={handleSubmitSignIn}>
         <div className='mb-3'>
           <Input
-            isClearable
+            isRequired
             className='max-w-xs w-full mb-1'
             style={{ width: '330px' }}
             type='email'
@@ -128,6 +129,7 @@ const SignInPage = () => {
         <div>
           <div className='mb-4'>
             <Input
+              isRequired
               className='max-w-xs w-full mb-1'
               type={isVisible ? 'text' : 'password'}
               label='Password'
@@ -156,18 +158,23 @@ const SignInPage = () => {
             )}
             {error && <p style={{ color: 'red' }}>{error}</p>}
           </div>
-          <div className='flex justify-center'></div>
-          <Button
-            className='w-full max-w-xs'
-            type='submit'
-            disabled={loading}
-            color='primary'
-            variant='ghost'
-          >
-            {loading ? '처리 중...' : '로그인하기'}
-          </Button>
+
+          <div className='flex justify-center mb-4'>
+            <Button
+              className='w-full max-w-xs'
+              type='submit'
+              disabled={loading}
+              color='primary'
+              variant='ghost'
+            >
+              {loading ? '처리 중...' : '로그인하기'}
+            </Button>
+          </div>
         </div>
       </form>
+      <Link href='/sign/signup'>
+        가입한 이력이 없으신가요? 회원가입하러 가기
+      </Link>
     </div>
   );
 };

--- a/src/app/sign/signup/page.tsx
+++ b/src/app/sign/signup/page.tsx
@@ -285,20 +285,20 @@ const SignUpPage = () => {
             {error && <div style={{ color: 'red' }}>{error}</div>}
           </div>
 
-          <div className='flex justify-center'></div>
-          <Button
-            className='w-full max-w-xs'
-            type='submit'
-            disabled={loading}
-            color='primary'
-            variant='ghost'
-          >
-            {loading ? '처리 중...' : '회원가입하기'}
-          </Button>
+          <div className='flex justify-center mb-4'>
+            <Button
+              className='w-full max-w-xs'
+              type='submit'
+              disabled={loading}
+              color='primary'
+              variant='ghost'
+            >
+              {loading ? '처리 중...' : '회원가입하기'}
+            </Button>
+          </div>
         </div>
       </form>
-      {/* 로그인 페이지로 이동하는 router 추가 */}
-      {/* <Link href={} /> */}
+      <Link href='/sign/signin'>이미 가입하셨나요? 로그인하러 가기</Link>
     </div>
   );
 };


### PR DESCRIPTION
## 왜 필요한가요?

- 회원가입 페이지에서 로그인 페이지로, 로그인 페이지에서 회원가입 페이지로 이동 가능하게 함으로써 사용자 편의성을 높일 수 있습니다.
- 닉네임 작성 시, 최대 길이를 설정하는 로직을 추가하여 사용자가 15자 이상 작성하였는지 굳이 확인하지 않아도 알 수 있게끔 해서 사용자 편리성을 확대했습니다.

## 어떤 변화가 생겼나요?

- 버튼 클릭 시, 로그인, 회원가입 페이지 이동 가능하게 처리하였습니다.
- 회원가입 페이지에서 닉네임 15자 이상 입력 안 되게 텍스트 최대 길이 설정하였습니다.
- 유효성 검사 메시지명 변경하였습니다.
- 로그인 성공 시, 보여줄 메시지 추가하였습니다.
  
## 스크린샷
<img width="432" alt="image" src="https://github.com/dahyeo-n/SPL/assets/154739298/efefa2bd-54df-4250-b532-58723de0e6bd">

<img width="486" alt="image" src="https://github.com/dahyeo-n/SPL/assets/154739298/9b55234f-ca09-4385-a2f1-825a2c23b35a">