### PR TITLE
Feat: 메인 페이지에서 로그인/비로그인 시, 보여지는 문구 다르게 처리

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,12 @@
 
 import React, { useEffect, useState } from 'react';
 import supabase from '@/supabaseClient';
+import { Session } from '@supabase/supabase-js';
 
 import Header from '@/components/common/Header';
 import { CustomCard } from '../components/common/CustomCard';
+
+import { useRouter } from 'next/navigation';
 
 import { Spacer } from '@nextui-org/react';
 
@@ -28,6 +31,52 @@ const Main: React.FC = () => {
   const [studyPlaces, setStudyPlaces] = useState<StudyPlace[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [selectedPlaceType, setSelectedPlaceType] = useState<string>('');
+  const [session, setSession] = useState<Session | null>(null);
+  const [nickname, setNickname] = useState<string | null>(null);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const getUserSession = async () => {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (error) throw error;
+        setSession(data.session);
+        console.log('로그인 데이터: ', data);
+      } catch (error) {
+        alert('Session 처리에 오류가 발생했습니다.');
+        console.log(error);
+      }
+    };
+
+    getUserSession();
+  }, [router]);
+
+  useEffect(() => {
+    if (session?.user && typeof session.user.email === 'string') {
+      fetchUserProfile(session.user.email);
+    }
+  }, [session?.user]);
+
+  const fetchUserProfile = async (email: string) => {
+    try {
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('nickname')
+        .eq('email', email)
+        .single();
+
+      if (error) {
+        throw error;
+      }
+
+      if (data) {
+        setNickname(data.nickname);
+      }
+    } catch (error) {
+      console.error('사용자 프로필을 불러오는 데 실패했습니다:', error);
+    }
+  };
 
   const fetchStudyPlaces = async (category: string, placeType: string) => {
     let query = supabase
@@ -73,7 +122,8 @@ const Main: React.FC = () => {
       <Header />
       <div>
         <main className='mx-20 lg:px-8'>
-          <div className='flex items-baseline justify-between pb-2 pt-6'>
+          {/* <div className='flex items-baseline justify-between pb-2 pt-6'> */}
+          <div className='flex items-baseline justify-start pb-2 pt-6'>
             <h1 className='text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-200'>
               Categories
             </h1>
@@ -96,6 +146,14 @@ const Main: React.FC = () => {
                 />
               </svg>
             </button> */}
+            <div className='pb-4'>
+              {/* flex items-center justify-start */}
+              <div className='ml-52 text-2xl font-bold text-gray-700 dark:text-gray-300'>
+                {nickname
+                  ? `${nickname}님이 목표와 꿈을 이루시도록 스플이 함께할게요!`
+                  : '3초만에 로그인해서 다양한 서비스를 만나보세요!'}
+              </div>
+            </div>
           </div>
 
           <section aria-labelledby='products-heading' className='pb-24 pt-6'>


### PR DESCRIPTION
## 왜 필요한가요?

- 사용자가 로그인 혹은 비로그인 시에 메인 페이지에서 어떤 문구를 보여주는지에 따라 사용자의 이후 액션(ex. 로그인하러 페이지 이동 등)이 달라지거나 환영 문구를 통해 한 고객으로서 환영받는다는 느낌을 드릴 수 있습니다.

## 어떤 변화가 생겼나요?

- 아래 사진과 같이 메인 페이지에서 로그인/비로그인 시, 보여지는 문구 다르게 처리되는 로직을 추가하였습니다.
  
## 스크린샷
<img width="1688" alt="image" src="https://github.com/dahyeo-n/SPL/assets/154739298/a04d036f-5ee2-4ec1-b91e-d739fa16714b">