### PR TITLE
Style: 카테고리 버튼 클릭에 따른 조건부 렌더링 CSS 적용

### DIFF
--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -286,12 +286,18 @@ const My: React.FC = () => {
                   </button>
                 </div>
                 <div>
-                  <button onClick={() => handleCategorySelection('scrapped')}>
+                  <button
+                    className='font-medium text-gray-400 dark:text-gray-500'
+                    onClick={() => handleCategorySelection('scrapped')}
+                  >
                     내가 스크랩한 장소
                   </button>
                 </div>
                 <div>
-                  <button onClick={() => handleCategorySelection('comments')}>
+                  <button
+                    className='font-medium text-gray-400 dark:text-gray-500'
+                    onClick={() => handleCategorySelection('comments')}
+                  >
                     내가 작성한 댓글
                   </button>
                 </div>
@@ -364,7 +370,10 @@ const My: React.FC = () => {
             <div className='grid grid-cols-1 gap-x-8 gap-y-10 lg:grid-cols-4'>
               <div className='lg:col-span-1 mt-2 space-y-6 pb-8 text-xl font-medium text-gray-900 dark:text-gray-200'>
                 <div>
-                  <button onClick={() => handleCategorySelection('profile')}>
+                  <button
+                    className='font-medium text-gray-400 dark:text-gray-500'
+                    onClick={() => handleCategorySelection('profile')}
+                  >
                     내 프로필 정보
                   </button>
                 </div>
@@ -374,7 +383,10 @@ const My: React.FC = () => {
                   </button>
                 </div>
                 <div>
-                  <button onClick={() => handleCategorySelection('comments')}>
+                  <button
+                    className='font-medium text-gray-400 dark:text-gray-500'
+                    onClick={() => handleCategorySelection('comments')}
+                  >
                     내가 작성한 댓글
                   </button>
                 </div>
@@ -423,12 +435,18 @@ const My: React.FC = () => {
             <div className='grid grid-cols-1 gap-x-8 gap-y-10 lg:grid-cols-4'>
               <div className='lg:col-span-1 mt-2 space-y-6 pb-8 text-xl font-medium text-gray-900 dark:text-gray-200'>
                 <div>
-                  <button onClick={() => handleCategorySelection('profile')}>
+                  <button
+                    className='font-medium text-gray-400 dark:text-gray-500'
+                    onClick={() => handleCategorySelection('profile')}
+                  >
                     내 프로필 정보
                   </button>
                 </div>
                 <div>
-                  <button onClick={() => handleCategorySelection('scrapped')}>
+                  <button
+                    className='font-medium text-gray-400 dark:text-gray-500'
+                    onClick={() => handleCategorySelection('scrapped')}
+                  >
                     내가 스크랩한 장소
                   </button>
                 </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -95,7 +95,7 @@ const Main: React.FC = () => {
     const { data, error } = await query;
 
     if (error) {
-      console.error('데이터를 불러오는 데 실패했습니다:', error);
+      console.error('데이터를 불러오는 데 실패했습니다: ', error);
     } else {
       setStudyPlaces(data || []);
     }
@@ -162,13 +162,20 @@ const Main: React.FC = () => {
                 <h3 className='sr-only'>Categories</h3>
                 <div className='space-y-6 pb-8 text-xl font-medium text-gray-900 dark:text-gray-200'>
                   {/* 필터 처리 로직 완성되면 map으로 돌릴 거임 */}
-                  <div>
-                    <button>추천</button>
-                  </div>
+                  <div>{/* <button>추천</button> */}</div>
                   <div>
                     <button
                       type='button'
-                      onClick={() => handleCategorySelection('')}
+                      onClick={() => {
+                        setSelectedCategory('');
+                        setSelectedPlaceType('');
+                        fetchStudyPlaces('', '');
+                      }}
+                      className={`${
+                        selectedCategory === '' && selectedPlaceType === ''
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       전체
                     </button>
@@ -177,6 +184,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handlePlaceTypeSelection('스터디룸')}
+                      className={`${
+                        selectedPlaceType === '스터디룸'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       스터디룸
                     </button>
@@ -185,6 +197,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handlePlaceTypeSelection('스터디카페')}
+                      className={`${
+                        selectedPlaceType === '스터디카페'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       스터디카페
                     </button>
@@ -193,6 +210,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handlePlaceTypeSelection('일반카페')}
+                      className={`${
+                        selectedPlaceType === '일반카페'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       일반카페
                     </button>
@@ -201,6 +223,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handlePlaceTypeSelection('북카페')}
+                      className={`${
+                        selectedPlaceType === '북카페'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       북카페
                     </button>
@@ -209,6 +236,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handleCategorySelection('노트북 이용')}
+                      className={`${
+                        selectedCategory === '노트북 이용'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       노트북 이용
                     </button>
@@ -217,6 +249,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handleCategorySelection('조용하고 한적한')}
+                      className={`${
+                        selectedCategory === '조용하고 한적한'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       조용하고 한적한
                     </button>
@@ -225,6 +262,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handleCategorySelection('세련되고 깔끔한')}
+                      className={`${
+                        selectedCategory === '세련되고 깔끔한'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       세련되고 깔끔한
                     </button>
@@ -233,6 +275,11 @@ const Main: React.FC = () => {
                     <button
                       type='button'
                       onClick={() => handleCategorySelection('뷰 맛집')}
+                      className={`${
+                        selectedCategory === '뷰 맛집'
+                          ? 'text-gray-900 dark:text-gray-200'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       뷰 맛집
                     </button>


### PR DESCRIPTION
## 왜 필요한가요?

- 사용자가 카테고리 버튼 클릭 시에 어떤 카테고리가 클릭된 건지 알아보기 편하게 하기 위해 필요합니다.

## 어떤 변화가 생겼나요?

- 메인 페이지와 마이 페이지의 카테고리 버튼 클릭에 따른 조건부 렌더링 CSS를 적용하였습니다.
  
## 스크린샷
<img width="1695" alt="image" src="https://github.com/dahyeo-n/SPL/assets/154739298/c678bd1b-b504-4c98-a451-18eb4c50d93c">

<img width="1695" alt="image" src="https://github.com/dahyeo-n/SPL/assets/154739298/357625d7-289f-4146-bd07-dc53c1599a2e">

<img width="930" alt="image" src="https://github.com/dahyeo-n/SPL/assets/154739298/395c4957-3d08-4a4c-9344-322bd61de541">