### PR TITLE
[사용자 피드백 반영] Fix: 로그인 상태에서 새로고침 시, 비로그인했을 때의 로딩 문구로 보이는 부분 로직 변경

### DIFF
--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -10,7 +10,7 @@ import Map from '../../../components/Map';
 
 import mediumZoom from 'medium-zoom';
 import { useTheme } from 'next-themes';
-import { toast } from 'react-toastify';
+import { ToastContainer, toast } from 'react-toastify';
 
 import {
   Image,
@@ -507,6 +507,7 @@ const Detail = () => {
 
   return (
     <>
+      <ToastContainer />
       <div className='flex justify-center w-full overflow-hidden mb-8'>
         <div
           className='rounded-lg w-[1000px] p-4 mx-2'

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,25 +1,24 @@
 'use client';
 
+import { Session } from '@supabase/supabase-js';
 import React, { useEffect, useState } from 'react';
 import supabase from '../../supabaseClient';
-import { Session } from '@supabase/supabase-js';
 
-import { CustomMainCard } from '../../components/common/CustomMainCard';
 import { useRouter } from 'next/navigation';
+import { CustomMainCard } from '../../components/common/CustomMainCard';
 
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 
 import {
+  Avatar,
   Card,
-  CardHeader,
   CardBody,
   CardFooter,
-  Avatar,
-  Button,
-  Spacer,
+  CardHeader,
+  Link,
   Select,
   SelectItem,
-  Link,
+  Spacer,
 } from '@nextui-org/react';
 
 interface UserProfile {

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -65,6 +65,7 @@ const My: React.FC = () => {
 
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [updatedNickname, setUpdatedNickname] = useState<string>('');
+  const [nicknameValid, setNicknameValid] = useState(true);
   const [updatedEmail, setUpdatedEmail] = useState<string>('');
   const [updatedUserType, setUpdatedUserType] = useState<string>('');
 
@@ -405,6 +406,7 @@ const My: React.FC = () => {
                     이메일
                   </label>
                   <input
+                    disabled
                     className='mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500'
                     name='email'
                     value={updatedEmail}

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -65,7 +65,6 @@ const My: React.FC = () => {
 
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [updatedNickname, setUpdatedNickname] = useState<string>('');
-  const [nicknameValid, setNicknameValid] = useState(true);
   const [updatedEmail, setUpdatedEmail] = useState<string>('');
   const [updatedUserType, setUpdatedUserType] = useState<string>('');
 
@@ -125,6 +124,11 @@ const My: React.FC = () => {
 
   const updateUserProfile = async () => {
     if (!session?.user) return;
+
+    if (updatedNickname.length < 1 || updatedNickname.length > 15) {
+      toast.error('닉네임을 1자 이상 15자 이내로 작성해주세요.');
+      return;
+    }
 
     const user_id = session.user.id;
     const { error } = await supabase
@@ -399,6 +403,9 @@ const My: React.FC = () => {
                   <input
                     className='mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500'
                     name='nickname'
+                    minLength={1}
+                    maxLength={15}
+                    placeholder='닉네임 1자 이상 15자 이내'
                     value={updatedNickname}
                     onChange={(e) => setUpdatedNickname(e.target.value)}
                   />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -413,31 +413,16 @@ const Main: React.FC = () => {
 
               {loading ? (
                 <div className='lg:col-span-3'>
-                  <div className='pt-2 pb-8'>
-                    <div className='text-2xl font-bold text-gray-700 dark:text-gray-300'>
-                      {nickname ? (
-                        `${nickname}님이 목표와 꿈을 이루시도록 스플이 함께할게요!`
-                      ) : (
-                        <>
-                          3초만에{' '}
-                          <Link href='/sign/signin'>
-                            <span className='text-indigo-500 underline decoration-indigo-500'>
-                              로그인
-                            </span>
-                          </Link>{' '}
-                          하셔서 다양한 서비스를 만나보세요!
-                        </>
-                      )}
-                    </div>
-                  </div>
                   <div className='flex flex-wrap'>{renderSkeletonCards(9)}</div>
                 </div>
               ) : (
                 <div className='lg:col-span-3'>
                   <div className='pt-2 pb-8'>
                     <div className='text-2xl font-bold text-gray-700 dark:text-gray-300'>
-                      {nickname ? (
+                      {session && nickname ? (
                         `${nickname}님이 목표와 꿈을 이루시도록 스플이 함께할게요!`
+                      ) : session ? (
+                        `님이 목표와 꿈을 이루시도록 스플이 함께할게요!`
                       ) : (
                         <>
                           3초만에{' '}


### PR DESCRIPTION
## 왜 필요한가요?

- 로그인을 하고 나서도 로딩 시에 메인 페이지에 "3초만에 로그인~" 문구가 떠서 사용자로 하여금 로그인이 안 된 것인지 착각하게 되는 부분을 수정해 착오를 없앴습니다.

## 어떤 변화가 생겼나요?

- 로그인 상태에서 새로고침 시, 비로그인했을 때의 로딩 문구로 보이는 부분 로직을 변경했습니다.
- 로그아웃 시에 새로고침해야 로그인 문구에서 로그아웃 문구로 반영되는 문제를 해결했습니다.
- 마이페이지에서 닉네임을 1자 이상 15자 이내로만 수정 가능하게 변경하였습니다.
- 마이페이지에서 이메일 수정 못 하게 하였습니다.
  
## 스크린샷 (수정된 코드 중 일부)
![image](https://github.com/dahyeo-n/SPL/assets/154739298/9052ccb1-145b-4976-8544-4463f2d1a27c)